### PR TITLE
Changed listening from stdout to stderr

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ var spawnCommand = function(command, args) {
   var eventEmitter = new EventEmitter();
   var started = false;
 
-  child.stdout.on('data', function (data) {
+  child.stderr.on('data', function (data) {
     process.stdout.write(data);
     if (/Started SocketListener/g.test(data.toString()) && !started) {
       eventEmitter.emit('ready', child);


### PR DESCRIPTION
Now selenium sends messages to stderr (prior to 2.39 version). As the
link below show, they say that sending messages through stdout was a
bug.
https://code.google.com/p/selenium/issues/detail?id=7957
