### PR TITLE
Download zip files safely.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -207,8 +207,7 @@ WebdriverManager.prototype._httpGetFile = function(fileUrl, fileName, callback) 
     url: fileUrl,
     proxy: this._resolveProxy(fileUrl)
   };
-  request(options, function (error, response) {
-  }).on('error', function(error) {
+  request(options).on('error', function(error) {
       fs.unlink(filePath);
       console.error('Error: Got error ' + error + ' from ' + fileUrl);
   }).on('response', function(response) {


### PR DESCRIPTION
The callback from `request()` can fire before the stream has finished pushing all data to disk.  This corrects this by waiting for the stream to emit an `end` event.
