### PR TITLE
updating versions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ var childProcess = require('child_process');
 var async = require('async');
 var EventEmitter = require('events').EventEmitter;
 
-var versions =  { "selenium": "2.44.0", "chromedriver": "2.12", "iedriver": "2.43.0" };
+var versions =  { "selenium": "2.45.0", "chromedriver": "2.14", "iedriver": "2.45.0" };
 
 /**
  * Get the major and minor version but ignore the patch (required for selenium


### PR DESCRIPTION
Selenium Server 2.45 update is required to test in firefox 35/36. Protractor has already been updated to pull in this newer server version, so should be good enough for this project right?

I went ahead and updated the chromedriver and iedriver versions as well to be on the same versions as protractor for everything.

Here's the the commit where they upgraded to 2.45 https://github.com/angular/protractor/commit/1159612ed76bb65612dbb2cc648e45928a251b10