### PR TITLE
Added --chromedriver-nw as acceptable CLI installable

### DIFF
--- a/bin/webdriver-manager
+++ b/bin/webdriver-manager
@@ -64,7 +64,7 @@ switch (argv._[0]) {
   case 'update':
 
     var installlables = Object.keys(argv).filter(function (key) {
-      return argv[key] && ( key === 'standalone' || key === 'chrome' || key === 'ie' );
+      return argv[key] && ( key === 'standalone' || key === 'chrome' || key === 'chromedriver-nw' || key === 'ie' );
     });
 
     webdriverManager.update(installlables, function (err, result) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -315,7 +315,7 @@ WebdriverManager.prototype.start = function (options, cb) {
   if (options.seleniumPort) {
     args.push('-port', options.seleniumPort);
   }
-  if (this.binaries.chrome.exists) {
+  if (this.binaries.chrome.exists || this.binaries['chromedriver-nw'].exists) {
     args.push('-Dwebdriver.chrome.driver=' +
               path.join(this.out_dir, executableName('chromedriver')));
   }


### PR DESCRIPTION
As mentioned in #13, when we tried to use the new `--chromedriver-nw` option, we saw that it was downloading the defaults (e.g. Selenium standalone and normal Chromedriver). Upon debugging, we found that we were filtering out `--chromedriver-nw` as an unrecognized option. 

In this PR:

- Added `--chromedriver-nw` as acceptable CLI installable
- Added detection for `chromedriver-nw` as binary to add `-D` for `chromedriver`

New successful log message:

```bash
$ bin/webdriver-manager update --chromedriver-nw
Updating selenium standalone
downloading http://selenium-release.storage.googleapis.com/2.46/selenium-server-standalone-2.46.0.jar...
Updating chromedriver (for nwjs)
downloading http://dl.nwjs.io/v0.12.2/chromedriver-nw-v0.12.2-linux-x64.tar.gz...
Updating chromedriver
downloading http://chromedriver.storage.googleapis.com/2.16/chromedriver_linux64.zip...
chromedriver_2.16.zip downloaded to /home/todd/github/webdriver-manager/selenium/chromedriver_2.16.zip
/home/todd/github/webdriver-manager/selenium/chromedriver_2.16.zip /home/todd/github/webdriver-manager/selenium
selenium-server-standalone-2.46.0.jar downloaded to /home/todd/github/webdriver-manager/selenium/selenium-server-standalone-2.46.0.jar
chromedriver-nw-v0.12.2-linux-x64.tar.gz downloaded to /home/todd/github/webdriver-manager/selenium/chromedriver-nw-v0.12.2-linux-x64.tar.gz
The following files were installed: /home/todd/github/webdriver-manager/selenium/selenium-server-standalone-2.46.0.jar /home/todd/github/webdriver-manager/selenium/chromedriver /home/todd/github/webdriver-manager/selenium/chromedriver
```