### PR TITLE
Updated versions in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
   "webdriverVersions": {
-    "selenium": "2.46.0",
-    "chromedriver": "2.16",
-    "iedriver": "2.46.0",
-    "chromedriver-nw": "0.12.2"
+    "selenium": "2.48.2",
+    "chromedriver": "2.20",
+    "iedriver": "2.48.0",
+    "chromedriver-nw": "0.12.3"
   }
 }


### PR DESCRIPTION
In Firefox 43.0, URL navigation via Selenium broke (SeleniumHQ/selenium#1385). Selenium has released an updated version of Selenium to handle this case but our `config.json` was out of date. We have updated it with the latest versions from:

http://www.seleniumhq.org/download/

http://dl.nwjs.io/

In this PR:

- Updated to latest versions in `config.json`